### PR TITLE
feat: 13 implementovat checker pro existenci exportu

### DIFF
--- a/api/v1/nfs_types.go
+++ b/api/v1/nfs_types.go
@@ -43,7 +43,8 @@ type NfsSpec struct {
 type NfsStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	Phase string `json:"phase,omitempty"`
+	Phase   string `json:"phase,omitempty"`
+	Message string `json:"message,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1/nfs_types.go
+++ b/api/v1/nfs_types.go
@@ -26,6 +26,7 @@ import (
 const (
 	PhasePending = "Pending"
 	PhaseBound   = "Bound"
+	PhaseUnknown = "Unknown"
 )
 
 // NfsSpec defines the desired state of Nfs

--- a/api/v1/nfs_types.go
+++ b/api/v1/nfs_types.go
@@ -27,6 +27,7 @@ const (
 	PhasePending = "Pending"
 	PhaseBound   = "Bound"
 	PhaseUnknown = "Unknown"
+	PhaseError   = "Error"
 )
 
 // NfsSpec defines the desired state of Nfs

--- a/config/crd/bases/storage.cfy.cz_nfs.yaml
+++ b/config/crd/bases/storage.cfy.cz_nfs.yaml
@@ -59,6 +59,8 @@ spec:
           status:
             description: NfsStatus defines the observed state of Nfs
             properties:
+              message:
+                type: string
               phase:
                 description: |-
                   INSERT ADDITIONAL STATUS FIELD - define observed state of cluster

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,6 +70,9 @@ spec:
         - /manager
         args:
         - --leader-elect
+        env:
+          - name: CHECK_EXPORTPATH
+            value: "false"
         image: controller:latest
         name: manager
         securityContext:

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -5,6 +5,6 @@ metadata:
   name: sample-nfs1
   namespace: example
 spec:
-  server: nfsserver.domena.tld
-  path: /directory/path
+  server: 172.16.4.102
+  path: /volume1/nfs-exports
 

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
+	github.com/rasky/go-xdr v0.0.0-20170124162913-1a41d1a06c93
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/prometheus/common v0.45.0 h1:2BGz0eBc2hdMDLnO/8n0jeB3oPrt2D08CekT0lne
 github.com/prometheus/common v0.45.0/go.mod h1:YJmSTw9BoKxJplESWWxlbyttQR4uaEcGyv9MZjVOJsY=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
+github.com/rasky/go-xdr v0.0.0-20170124162913-1a41d1a06c93 h1:UVArwN/wkKjMVhh2EQGC0tEc1+FqiLlvYXY5mQ2f8Wg=
+github.com/rasky/go-xdr v0.0.0-20170124162913-1a41d1a06c93/go.mod h1:Nfe4efndBz4TibWycNE+lqyJZiMX4ycx+QKV8Ta0f/o=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/internal/controller/nfs_controller.go
+++ b/internal/controller/nfs_controller.go
@@ -110,14 +110,7 @@ func (r *NfsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	if err != nil {
 		log.Error(err, "unable to export volumes")
 	}
-	/*
-		// Vypsat data ve formátu JSON na standardní výstup
-		jsonData, err := json.MarshalIndent(AllNfsExports, "", "    ")
-		if err != nil {
-			log.Error(err, "Chyba kódování do formátu JSON")
-		}
-		fmt.Println(string(jsonData))
-	*/
+
 	if !containsExportPath(AllNfsExports, nfs.Spec.Path) {
 		// Nastavime status na nejaky Error a zajistime novou rekoncilaci za cca 10s
 		statusUpdate := storagev1.NfsStatus{

--- a/internal/controller/nfs_controller.go
+++ b/internal/controller/nfs_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"os"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -101,27 +102,49 @@ func (r *NfsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	// Verify the existence of spec.path on the Nfs server
-	mount, err := nfsclient.DialMount(nfs.Spec.Server)
-	if err != nil {
-		log.Error(err, "unable to dial MOUNT service")
-	}
-	defer mount.Close()
-	AllNfsExports, err := mount.Exports()
-	if err != nil {
-		log.Error(err, "unable to export volumes")
-	}
+	if os.Getenv("CHECK_EXPORTPATH") == "true" {
+		mount, err := nfsclient.DialMount(nfs.Spec.Server)
+		if err != nil {
+			log.Error(err, "unable to dial MOUNT service")
+			// Nastavime status Nfs objektu
+			statusUpdate := storagev1.NfsStatus{
+				Phase:   "Error",
+				Message: "Unable to dial MOUNT service.",
+			}
+			nfs.Status = statusUpdate
+			if err := r.Status().Update(ctx, nfs); err != nil {
+				log.Error(err, "Failed to update Nfs status")
+			}
+			return ctrl.Result{}, nil
+		}
+		defer mount.Close()
+		AllNfsExports, err := mount.Exports()
+		if err != nil {
+			log.Error(err, "unable to export volumes")
+			// Nastavime status Nfs objektu
+			statusUpdate := storagev1.NfsStatus{
+				Phase:   "Error",
+				Message: "Unable to export volumes.",
+			}
+			nfs.Status = statusUpdate
+			if err := r.Status().Update(ctx, nfs); err != nil {
+				log.Error(err, "Failed to update Nfs status")
+			}
+			return ctrl.Result{}, nil
+		}
 
-	if !containsExportPath(AllNfsExports, nfs.Spec.Path) {
-		// Nastavime status na nejaky Error a zajistime novou rekoncilaci za cca 10s
-		statusUpdate := storagev1.NfsStatus{
-			Phase:   "Pending",
-			Message: "The NFS server does not export the specified directory " + nfs.Spec.Path + ".",
+		if !containsExportPath(AllNfsExports, nfs.Spec.Path) {
+			// Nastavime status na nejaky Error a zajistime novou rekoncilaci za cca 10s
+			statusUpdate := storagev1.NfsStatus{
+				Phase:   "Pending",
+				Message: "The NFS server does not export the specified directory " + nfs.Spec.Path + ".",
+			}
+			nfs.Status = statusUpdate
+			if err := r.Status().Update(ctx, nfs); err != nil {
+				log.Error(err, "Failed to update Nfs status")
+			}
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
-		nfs.Status = statusUpdate
-		if err := r.Status().Update(ctx, nfs); err != nil {
-			log.Error(err, "Failed to update Nfs status")
-		}
-		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
 	// Create/Update/Delete PersistentVolumeClaim

--- a/internal/controller/nfs_controller.go
+++ b/internal/controller/nfs_controller.go
@@ -100,7 +100,7 @@ func (r *NfsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, nil
 	}
 
-	// Check existing mountPath
+	// Verify the existence of spec.path on the Nfs server
 	mount, err := nfsclient.DialMount(nfs.Spec.Server)
 	if err != nil {
 		log.Error(err, "unable to dial MOUNT service")

--- a/pkg/nfsclient/error.go
+++ b/pkg/nfsclient/error.go
@@ -1,0 +1,123 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+package nfsclient
+
+import "os"
+
+const (
+	NFS3Ok             = 0
+	NFS3ErrPerm        = 1
+	NFS3ErrNoEnt       = 2
+	NFS3ErrIO          = 5
+	NFS3ErrNXIO        = 6
+	NFS3ErrAcces       = 13
+	NFS3ErrExist       = 17
+	NFS3ErrXDev        = 18
+	NFS3ErrNoDev       = 19
+	NFS3ErrNotDir      = 20
+	NFS3ErrIsDir       = 21
+	NFS3ErrInval       = 22
+	NFS3ErrFBig        = 27
+	NFS3ErrNoSpc       = 28
+	NFS3ErrROFS        = 30
+	NFS3ErrMLink       = 31
+	NFS3ErrNameTooLong = 63
+	NFS3ErrNotEmpty    = 66
+	NFS3ErrDQuot       = 69
+	NFS3ErrStale       = 70
+	NFS3ErrRemote      = 71
+	NFS3ErrBadHandle   = 10001
+	NFS3ErrNotSync     = 10002
+	NFS3ErrBadCookie   = 10003
+	NFS3ErrNotSupp     = 10004
+	NFS3ErrTooSmall    = 10005
+	NFS3ErrServerFault = 10006
+	NFS3ErrBadType     = 10007
+)
+
+var errToName = map[uint32]string{
+	0:     "NFS3_OK",
+	1:     "NFS3ERR_PERM",
+	2:     "NFS3ERR_NOENT",
+	5:     "NFS3ERR_IO",
+	6:     "NFS3ERR_NXIO",
+	13:    "NFS3ERR_ACCES",
+	17:    "NFS3ERR_EXIST",
+	18:    "NFS3ERR_XDEV",
+	19:    "NFS3ERR_NODEV",
+	20:    "NFS3ERR_NOTDIR",
+	21:    "NFS3ERR_ISDIR",
+	22:    "NFS3ERR_INVAL",
+	27:    "NFS3ERR_FBIG",
+	28:    "NFS3ERR_NOSPC",
+	30:    "NFS3ERR_ROFS",
+	31:    "NFS3ERR_MLINK",
+	63:    "NFS3ERR_NAMETOOLONG",
+	66:    "NFS3ERR_NOTEMPTY",
+	69:    "NFS3ERR_DQUOT",
+	70:    "NFS3ERR_STALE",
+	71:    "NFS3ERR_REMOTE",
+	10001: "NFS3ERR_BADHANDLE",
+	10002: "NFS3ERR_NOT_SYNC",
+	10003: "NFS3ERR_BAD_COOKIE",
+	10004: "NFS3ERR_NOTSUPP",
+	10005: "NFS3ERR_TOOSMALL",
+	10006: "NFS3ERR_SERVERFAULT",
+	10007: "NFS3ERR_BADTYPE",
+}
+
+func NFS3Error(errnum uint32) error {
+	switch errnum {
+	case NFS3Ok:
+		return nil
+	case NFS3ErrPerm:
+		return os.ErrPermission
+	case NFS3ErrExist:
+		return os.ErrExist
+	case NFS3ErrNoEnt:
+		return os.ErrNotExist
+	default:
+		if errStr, ok := errToName[errnum]; ok {
+			return &Error{
+				ErrorNum:    errnum,
+				ErrorString: errStr,
+			}
+		}
+
+		return os.ErrInvalid
+	}
+}
+
+// Error represents an unexpected I/O behavior.
+type Error struct {
+	ErrorNum    uint32
+	ErrorString string
+}
+
+func (err *Error) Error() string { return err.ErrorString }
+
+func IsNotEmptyError(err error) bool {
+	nfsErr, ok := err.(*Error)
+	if !ok {
+		return false
+	}
+
+	if nfsErr.ErrorNum == NFS3ErrNotEmpty {
+		return true
+	}
+
+	return false
+}
+
+func IsNotDirError(err error) bool {
+	nfsErr, ok := err.(*Error)
+	if !ok {
+		return false
+	}
+
+	if nfsErr.ErrorNum == NFS3ErrNotDir {
+		return true
+	}
+
+	return false
+}

--- a/pkg/nfsclient/mount.go
+++ b/pkg/nfsclient/mount.go
@@ -1,0 +1,248 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+package nfsclient
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"strings"
+	"unicode"
+
+	"github.com/Cloud-for-You/storage-operator/pkg/nfsclient/rpc"
+	"github.com/Cloud-for-You/storage-operator/pkg/nfsclient/xdr"
+)
+
+const (
+	MountProg = 100005
+	MountVers = 3
+
+	MountProc3Null   = 0
+	MountProc3MNT    = 1
+	MountProc3UMNT   = 3
+	MountProc3Export = 5
+
+	MNT3Ok             = 0     // no error
+	MNT3ErrPerm        = 1     // Not owner
+	MNT3ErrNoEnt       = 2     // No such file or directory
+	MNT3ErrIO          = 5     // I/O error
+	MNT3ErrAcces       = 13    // Permission denied
+	MNT3ErrNotDir      = 20    // Not a directory
+	MNT3ErrInval       = 22    // Invalid argument
+	MNT3ErrNameTooLong = 63    // Filename too long
+	MNT3ErrNotSupp     = 10004 // Operation not supported
+	MNT3ErrServerFault = 10006 // A failure on the server
+)
+
+type Mount struct {
+	*rpc.Client
+	auth    rpc.Auth
+	dirPath string
+	Addr    string
+}
+
+type Export struct {
+	Directory string
+	Groups    []string
+}
+
+func (m *Mount) Unmount() error {
+	type umount struct {
+		rpc.Header
+		Dirpath string
+	}
+
+	_, err := m.Call(&umount{
+		rpc.Header{
+			Rpcvers: 2,
+			Prog:    MountProg,
+			Vers:    MountVers,
+			Proc:    MountProc3UMNT,
+			// Weirdly, the spec calls for AUTH_UNIX or better, but AUTH_NULL
+			// works here on a linux NFS kernel server.  Follow the spec
+			// anyway.
+			Cred: m.auth,
+			Verf: rpc.AuthNull,
+		},
+		m.dirPath,
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Mount) Mount(dirpath string, auth rpc.Auth) (*Target, error) {
+	type mount struct {
+		rpc.Header
+		Dirpath string
+	}
+
+	res, err := m.Call(&mount{
+		rpc.Header{
+			Rpcvers: 2,
+			Prog:    MountProg,
+			Vers:    MountVers,
+			Proc:    MountProc3MNT,
+			Cred:    auth,
+			Verf:    rpc.AuthNull,
+		},
+		dirpath,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	mountstat3, err := xdr.ReadUint32(res)
+	if err != nil {
+		return nil, err
+	}
+
+	switch mountstat3 {
+	case MNT3Ok:
+		fh, err := xdr.ReadOpaque(res)
+		if err != nil {
+			return nil, err
+		}
+
+		_, _ = xdr.ReadUint32List(res)
+
+		m.dirPath = dirpath
+		m.auth = auth
+
+		vol, err := NewTarget(m.Addr, auth, fh, dirpath)
+		if err != nil {
+			return nil, err
+		}
+
+		return vol, nil
+
+	case MNT3ErrPerm:
+		return nil, errors.New("MNT3ERR_PERM")
+	case MNT3ErrNoEnt:
+		return nil, errors.New("MNT3ERR_NOENT")
+	case MNT3ErrIO:
+		return nil, errors.New("MNT3ERR_IO")
+	case MNT3ErrAcces:
+		return nil, errors.New("MNT3ERR_ACCES")
+	case MNT3ErrNotDir:
+		return nil, errors.New("MNT3ERR_NOTDIR")
+	case MNT3ErrNameTooLong:
+		return nil, errors.New("MNT3ERR_NAMETOOLONG")
+	}
+	return nil, fmt.Errorf("unknown mount stat: %d", mountstat3)
+}
+
+func (m *Mount) Exports() ([]Export, error) {
+	type export struct {
+		rpc.Header
+	}
+	msg := &export{
+		rpc.Header{
+			Rpcvers: 2,
+			Prog:    MountProg,
+			Vers:    MountVers,
+			Proc:    MountProc3Export,
+			Cred:    rpc.AuthNull,
+			Verf:    rpc.AuthNull,
+		},
+	}
+
+	reply, err := m.Call(msg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Precteme data z io.ReadSeeker a ulozime v typu []byte
+	decodedData, err := readData(reply)
+	if err != nil {
+		log.Fatalf("Error reading data: %v", err)
+	}
+	// Extrahujeme data z dekodovanych dat do type []Export
+	exports, err := extractExports(decodedData)
+	if err != nil {
+		log.Fatalf("Error extracting data: %v", err)
+	}
+	return exports, nil
+}
+
+func DialMount(addr string) (*Mount, error) {
+	// get MOUNT port
+	m := rpc.Mapping{
+		Prog: MountProg,
+		Vers: MountVers,
+		Prot: rpc.IPProtoTCP,
+		Port: 0,
+	}
+
+	client, err := DialService(addr, m)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Mount{
+		Client: client,
+		Addr:   addr,
+	}, nil
+}
+
+// Data reader from io.ReadSeeker
+func readData(rs io.ReadSeeker) ([]byte, error) {
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, rs)
+	if err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// Funkce pro extrakci adresářů z byte slice
+func extractExports(data []byte) ([]Export, error) {
+	var exports []Export
+	var currentExport *Export
+	// Procházet byte slice a hledat adresáře
+	parts := bytes.Split(data, []byte{0})
+	for _, part := range parts {
+		// Převést byte slice na string a trimnout whitespace
+		str := strings.TrimSpace(string(part))
+		// Přidat do seznamu exportů, pokud není prázdný a není [1]
+		if len(str) > 0 && !bytes.Equal([]byte(str), []byte{1}) {
+			str = removeNonPrintableChars(str)
+			if _, _, err := net.ParseCIDR(str); err == nil || net.ParseIP(str) != nil {
+				// Jedná se o IP adresu nebo rozsah
+				if currentExport != nil {
+					currentExport.Groups = append(currentExport.Groups, str)
+				}
+			} else {
+				// Není IP adresa ani rozsah, je to adresář
+				if currentExport != nil {
+					exports = append(exports, *currentExport)
+				}
+				currentExport = &Export{
+					Directory: str,
+					Groups:    nil, // Začneme s prázdným seznamem skupin
+				}
+			}
+		}
+	}
+	// Přidání posledního exportu, pokud existuje
+	if currentExport != nil {
+		exports = append(exports, *currentExport)
+	}
+
+	return exports, nil
+}
+
+func removeNonPrintableChars(str string) string {
+	var result []rune
+	for _, r := range str {
+		if unicode.IsPrint(r) {
+			result = append(result, r)
+		}
+	}
+	return string(result)
+}

--- a/pkg/nfsclient/nfs.go
+++ b/pkg/nfsclient/nfs.go
@@ -1,0 +1,304 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+package nfsclient
+
+import (
+	"fmt"
+	"math/rand"
+	"net"
+	"os"
+	"os/user"
+	"syscall"
+	"time"
+
+	"github.com/Cloud-for-You/storage-operator/pkg/nfsclient/rpc"
+	"github.com/Cloud-for-You/storage-operator/pkg/nfsclient/util"
+)
+
+const (
+	Nfs3Prog = 100003
+	Nfs3Vers = 3
+
+	// program methods
+	NFSProc3Lookup      = 3
+	NFSProc3Readlink    = 5
+	NFSProc3Read        = 6
+	NFSProc3Write       = 7
+	NFSProc3Create      = 8
+	NFSProc3Mkdir       = 9
+	NFSProc3Remove      = 12
+	NFSProc3RmDir       = 13
+	NFSProc3ReadDirPlus = 17
+	NFSProc3FSInfo      = 19
+	NFSProc3Commit      = 21
+
+	// The size in bytes of the opaque cookie verifier passed by
+	// READDIR and READDIRPLUS.
+	NFS3_COOKIEVERFSIZE = 8
+
+	// file types
+	NF3Reg  = 1
+	NF3Dir  = 2
+	NF3Blk  = 3
+	NF3Chr  = 4
+	NF3Lnk  = 5
+	NF3Sock = 6
+	NF3FIFO = 7
+)
+
+type Diropargs3 struct {
+	FH       []byte
+	Filename string
+}
+
+type Sattr3 struct {
+	Mode  SetMode
+	UID   SetUID
+	GID   SetUID
+	Size  SetSize
+	Atime SetTime
+	Mtime SetTime
+}
+
+type SetMode struct {
+	SetIt bool   `xdr:"union"`
+	Mode  uint32 `xdr:"unioncase=1"`
+}
+
+type SetUID struct {
+	SetIt bool   `xdr:"union"`
+	UID   uint32 `xdr:"unioncase=1"`
+}
+
+type SetSize struct {
+	SetIt bool   `xdr:"union"`
+	Size  uint64 `xdr:"unioncase=1"`
+}
+
+type TimeHow int
+
+const (
+	DontChange TimeHow = iota
+	SetToServerTime
+	SetToClientTime
+)
+
+type SetTime struct {
+	SetIt TimeHow  `xdr:"union"`
+	Time  NFS3Time `xdr:"unioncase=2"` //SetToClientTime
+}
+
+type NFS3Time struct {
+	Seconds  uint32
+	Nseconds uint32
+}
+
+type Fattr struct {
+	Type                uint32
+	FileMode            uint32
+	Nlink               uint32
+	UID                 uint32
+	GID                 uint32
+	Filesize            uint64
+	Used                uint64
+	SpecData            [2]uint32
+	FSID                uint64
+	Fileid              uint64
+	Atime, Mtime, Ctime NFS3Time
+}
+
+func (f *Fattr) Name() string {
+	return ""
+}
+
+func (f *Fattr) Size() int64 {
+	return int64(f.Filesize)
+}
+
+func (f *Fattr) Mode() os.FileMode {
+	return os.FileMode(f.FileMode)
+}
+
+func (f *Fattr) ModTime() time.Time {
+	return time.Unix(int64(f.Mtime.Seconds), int64(f.Mtime.Nseconds))
+}
+
+func (f *Fattr) IsDir() bool {
+	return f.Type == NF3Dir
+}
+
+func (f *Fattr) Sys() interface{} {
+	return nil
+}
+
+type PostOpFH3 struct {
+	IsSet bool   `xdr:"union"`
+	FH    []byte `xdr:"unioncase=1"`
+}
+
+type PostOpAttr struct {
+	IsSet bool  `xdr:"union"`
+	Attr  Fattr `xdr:"unioncase=1"`
+}
+
+type EntryPlus struct {
+	FileId   uint64
+	FileName string
+	Cookie   uint64
+	Attr     PostOpAttr
+	Handle   PostOpFH3
+	// NextEntry *EntryPlus
+}
+
+func (e *EntryPlus) Name() string {
+	return e.FileName
+}
+
+func (e *EntryPlus) Size() int64 {
+	if !e.Attr.IsSet {
+		return 0
+	}
+
+	return e.Attr.Attr.Size()
+}
+
+func (e *EntryPlus) Mode() os.FileMode {
+	if !e.Attr.IsSet {
+		return 0
+	}
+
+	return e.Attr.Attr.Mode()
+}
+
+func (e *EntryPlus) ModTime() time.Time {
+	if !e.Attr.IsSet {
+		return time.Time{}
+	}
+
+	return e.Attr.Attr.ModTime()
+}
+
+func (e *EntryPlus) IsDir() bool {
+	if !e.Attr.IsSet {
+		return false
+	}
+
+	return e.Attr.Attr.IsDir()
+}
+
+func (e *EntryPlus) Sys() interface{} {
+	if !e.Attr.IsSet {
+		return 0
+	}
+
+	return e.FileId
+}
+
+type WccData struct {
+	Before struct {
+		IsSet bool     `xdr:"union"`
+		Size  uint64   `xdr:"unioncase=1"`
+		MTime NFS3Time `xdr:"unioncase=1"`
+		CTime NFS3Time `xdr:"unioncase=1"`
+	}
+	After PostOpAttr
+}
+
+type FSInfo struct {
+	Attr       PostOpAttr
+	RTMax      uint32
+	RTPref     uint32
+	RTMult     uint32
+	WTMax      uint32
+	WTPref     uint32
+	WTMult     uint32
+	DTPref     uint32
+	Size       uint64
+	TimeDelta  NFS3Time
+	Properties uint32
+}
+
+// Dial an RPC svc after getting the port from the portmapper
+func DialService(addr string, prog rpc.Mapping) (*rpc.Client, error) {
+	pm, err := rpc.DialPortmapper("tcp", addr)
+	if err != nil {
+		util.Errorf("Failed to connect to portmapper: %s", err)
+		return nil, err
+	}
+	defer pm.Close()
+
+	port, err := pm.Getport(prog)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := dialService(addr, port)
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+func dialService(addr string, port int) (*rpc.Client, error) {
+	var (
+		ldr    *net.TCPAddr
+		client *rpc.Client
+	)
+
+	usr, err := user.Current()
+
+	// Unless explicitly configured, the target will likely reject connections
+	// from non-privileged ports.
+	if err == nil && usr.Uid == "0" {
+		r1 := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+		var p int
+		for {
+			p = r1.Intn(1024)
+			if p < 0 {
+				continue
+			}
+
+			ldr = &net.TCPAddr{
+				Port: p,
+			}
+
+			raddr := fmt.Sprintf("%s:%d", addr, port)
+			util.Debugf("Connecting to %s", raddr)
+
+			client, err = rpc.DialTCP("tcp", ldr, raddr)
+			if err == nil {
+				break
+			}
+			// bind error, try again
+			if isAddrInUse(err) {
+				continue
+			}
+
+			return nil, err
+		}
+
+		util.Debugf("using random port %d -> %d", p, port)
+	} else {
+		raddr := fmt.Sprintf("%s:%d", addr, port)
+		util.Debugf("Connecting to %s from unprivileged port", raddr)
+
+		client, err = rpc.DialTCP("tcp", ldr, raddr)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return client, nil
+}
+
+func isAddrInUse(err error) bool {
+	if er, ok := (err.(*net.OpError)); ok {
+		if syser, ok := er.Err.(*os.SyscallError); ok {
+			return syser.Err == syscall.EADDRINUSE
+		}
+	}
+
+	return false
+}

--- a/pkg/nfsclient/rpc/client.go
+++ b/pkg/nfsclient/rpc/client.go
@@ -1,0 +1,178 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+package rpc
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"github.com/Cloud-for-You/storage-operator/pkg/nfsclient/util"
+	"github.com/Cloud-for-You/storage-operator/pkg/nfsclient/xdr"
+)
+
+const (
+	MsgAccepted = iota
+	MsgDenied
+)
+
+const (
+	Success = iota
+	ProgUnavail
+	ProgMismatch
+	ProcUnavail
+	GarbageArgs
+	SystemErr
+)
+
+const (
+	RpcMismatch = iota
+)
+
+var xid uint32
+
+func init() {
+	// seed the XID (which is set by the client)
+	xid = rand.New(rand.NewSource(time.Now().UnixNano())).Uint32()
+}
+
+type Client struct {
+	*tcpTransport
+}
+
+func DialTCP(network string, ldr *net.TCPAddr, addr string) (*Client, error) {
+	a, err := net.ResolveTCPAddr(network, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := net.DialTCP(a.Network(), ldr, a)
+	if err != nil {
+		return nil, err
+	}
+
+	t := &tcpTransport{
+		r:  bufio.NewReader(conn),
+		wc: conn,
+	}
+
+	return &Client{t}, nil
+}
+
+type message struct {
+	Xid     uint32
+	Msgtype uint32
+	Body    interface{}
+}
+
+func (c *Client) Call(call interface{}) (io.ReadSeeker, error) {
+	retries := 1
+
+	msg := &message{
+		Xid:  atomic.AddUint32(&xid, 1),
+		Body: call,
+	}
+
+retry:
+	w := new(bytes.Buffer)
+	if err := xdr.Write(w, msg); err != nil {
+		return nil, err
+	}
+
+	if _, err := c.Write(w.Bytes()); err != nil {
+		return nil, err
+	}
+
+	res, err := c.recv()
+	if err != nil {
+		return nil, err
+	}
+
+	xid, err := xdr.ReadUint32(res)
+	if err != nil {
+		return nil, err
+	}
+
+	if xid != msg.Xid {
+		return nil, fmt.Errorf("xid did not match, expected: %x, received: %x", msg.Xid, xid)
+	}
+
+	mtype, err := xdr.ReadUint32(res)
+	if err != nil {
+		return nil, err
+	}
+
+	if mtype != 1 {
+		return nil, fmt.Errorf("message as not a reply: %d", mtype)
+	}
+
+	status, err := xdr.ReadUint32(res)
+	if err != nil {
+		return nil, err
+	}
+
+	switch status {
+	case MsgAccepted:
+
+		// padding
+		_, err = xdr.ReadUint32(res)
+		if err != nil {
+			panic(err.Error())
+		}
+
+		opaque_len, err := xdr.ReadUint32(res)
+		if err != nil {
+			panic(err.Error())
+		}
+
+		_, err = res.Seek(int64(opaque_len), io.SeekCurrent)
+		if err != nil {
+			panic(err.Error())
+		}
+
+		acceptStatus, _ := xdr.ReadUint32(res)
+
+		switch acceptStatus {
+		case Success:
+			return res, nil
+		case ProgUnavail:
+			return nil, fmt.Errorf("rpc: PROG_UNAVAIL - server does not recognize the program number")
+		case ProgMismatch:
+			return nil, fmt.Errorf("rpc: PROG_MISMATCH - program version does not exist on the server")
+		case ProcUnavail:
+			return nil, fmt.Errorf("rpc: PROC_UNAVAIL - unrecognized procedure number")
+		case GarbageArgs:
+			// emulate Linux behaviour for GARBAGE_ARGS
+			if retries > 0 {
+				util.Debugf("Retrying on GARBAGE_ARGS per linux semantics")
+				retries--
+				goto retry
+			}
+
+			return nil, fmt.Errorf("rpc: GARBAGE_ARGS - rpc arguments cannot be XDR decoded")
+		case SystemErr:
+			return nil, fmt.Errorf("rpc: SYSTEM_ERR - unknown error on server")
+		default:
+			return nil, fmt.Errorf("rpc: unknown accepted status error: %d", acceptStatus)
+		}
+
+	case MsgDenied:
+		rejectStatus, _ := xdr.ReadUint32(res)
+		switch rejectStatus {
+		case RpcMismatch:
+
+		default:
+			return nil, fmt.Errorf("rejectedStatus was not valid: %d", rejectStatus)
+		}
+
+	default:
+		return nil, fmt.Errorf("rejectedStatus was not valid: %d", status)
+	}
+
+	panic("unreachable")
+}

--- a/pkg/nfsclient/rpc/portmap.go
+++ b/pkg/nfsclient/rpc/portmap.go
@@ -1,0 +1,79 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+package rpc
+
+import (
+	"fmt"
+
+	"github.com/Cloud-for-You/storage-operator/pkg/nfsclient/xdr"
+)
+
+// PORTMAP
+// RFC 1057 Section A.1
+
+const (
+	PmapPort = 111
+	PmapProg = 100000
+	PmapVers = 2
+
+	PmapProcGetPort = 3
+
+	IPProtoTCP = 6
+	IPProtoUDP = 17
+)
+
+type Header struct {
+	Rpcvers uint32
+	Prog    uint32
+	Vers    uint32
+	Proc    uint32
+	Cred    Auth
+	Verf    Auth
+}
+
+type Mapping struct {
+	Prog uint32
+	Vers uint32
+	Prot uint32
+	Port uint32
+}
+
+type Portmapper struct {
+	*Client
+	host string
+}
+
+func (p *Portmapper) Getport(mapping Mapping) (int, error) {
+	type getport struct {
+		Header
+		Mapping
+	}
+	msg := &getport{
+		Header{
+			Rpcvers: 2,
+			Prog:    PmapProg,
+			Vers:    PmapVers,
+			Proc:    PmapProcGetPort,
+			Cred:    AuthNull,
+			Verf:    AuthNull,
+		},
+		mapping,
+	}
+	res, err := p.Call(msg)
+	if err != nil {
+		return 0, err
+	}
+	port, err := xdr.ReadUint32(res)
+	if err != nil {
+		return int(port), err
+	}
+	return int(port), nil
+}
+
+func DialPortmapper(net, host string) (*Portmapper, error) {
+	client, err := DialTCP(net, nil, fmt.Sprintf("%s:%d", host, PmapPort))
+	if err != nil {
+		return nil, err
+	}
+	return &Portmapper{client, host}, nil
+}

--- a/pkg/nfsclient/rpc/rpc.go
+++ b/pkg/nfsclient/rpc/rpc.go
@@ -1,0 +1,47 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+package rpc
+
+import (
+	"bytes"
+	"math/rand"
+	"time"
+
+	"github.com/Cloud-for-You/storage-operator/pkg/nfsclient/xdr"
+)
+
+type Auth struct {
+	Flavor uint32
+	Body   []byte
+}
+
+var AuthNull Auth
+
+type AuthUnix struct {
+	Stamp       uint32
+	Machinename string
+	Uid         uint32
+	Gid         uint32
+	GidLen      uint32
+	Gids        uint32
+}
+
+func NewAuthUnix(machinename string, uid, gid uint32) *AuthUnix {
+	return &AuthUnix{
+		Stamp:       rand.New(rand.NewSource(time.Now().UnixNano())).Uint32(),
+		Machinename: machinename,
+		Uid:         uid,
+		Gid:         gid,
+		GidLen:      1,
+	}
+}
+
+// Auth converts a into an Auth opaque struct
+func (a AuthUnix) Auth() Auth {
+	w := new(bytes.Buffer)
+	xdr.Write(w, a)
+	return Auth{
+		1,
+		w.Bytes(),
+	}
+}

--- a/pkg/nfsclient/rpc/tcp.go
+++ b/pkg/nfsclient/rpc/tcp.go
@@ -1,0 +1,71 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+package rpc
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"sync"
+	"time"
+)
+
+type tcpTransport struct {
+	r       io.Reader
+	wc      net.Conn
+	timeout time.Duration
+
+	rlock, wlock sync.Mutex
+}
+
+// Get the response from the conn, buffer the contents, and return a reader to
+// it.
+func (t *tcpTransport) recv() (io.ReadSeeker, error) {
+	t.rlock.Lock()
+	defer t.rlock.Unlock()
+	if t.timeout != 0 {
+		deadline := time.Now().Add(t.timeout)
+		t.wc.SetReadDeadline(deadline)
+	}
+
+	var hdr uint32
+	if err := binary.Read(t.r, binary.BigEndian, &hdr); err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, hdr&0x7fffffff)
+	if _, err := io.ReadFull(t.r, buf); err != nil {
+		return nil, err
+	}
+
+	return bytes.NewReader(buf), nil
+}
+
+func (t *tcpTransport) Write(buf []byte) (int, error) {
+	t.wlock.Lock()
+	defer t.wlock.Unlock()
+
+	var hdr uint32 = uint32(len(buf)) | 0x80000000
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, hdr)
+	if t.timeout != 0 {
+		deadline := time.Now().Add(t.timeout)
+		t.wc.SetWriteDeadline(deadline)
+	}
+	n, err := t.wc.Write(append(b, buf...))
+
+	return n, err
+}
+
+func (t *tcpTransport) Close() error {
+	return t.wc.Close()
+}
+
+func (t *tcpTransport) SetTimeout(d time.Duration) {
+	t.timeout = d
+	if d == 0 {
+		var zeroTime time.Time
+		t.wc.SetDeadline(zeroTime)
+	}
+}

--- a/pkg/nfsclient/target.go
+++ b/pkg/nfsclient/target.go
@@ -1,0 +1,558 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+package nfsclient
+
+import (
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/Cloud-for-You/storage-operator/pkg/nfsclient/rpc"
+	"github.com/Cloud-for-You/storage-operator/pkg/nfsclient/util"
+	"github.com/Cloud-for-You/storage-operator/pkg/nfsclient/xdr"
+)
+
+type Target struct {
+	*rpc.Client
+
+	auth    rpc.Auth
+	fh      []byte
+	dirPath string
+	fsinfo  *FSInfo
+}
+
+func NewTarget(addr string, auth rpc.Auth, fh []byte, dirpath string) (*Target, error) {
+	m := rpc.Mapping{
+		Prog: Nfs3Prog,
+		Vers: Nfs3Vers,
+		Prot: rpc.IPProtoTCP,
+		Port: 0,
+	}
+
+	client, err := DialService(addr, m)
+	if err != nil {
+		return nil, err
+	}
+
+	vol := &Target{
+		Client:  client,
+		auth:    auth,
+		fh:      fh,
+		dirPath: dirpath,
+	}
+
+	fsinfo, err := vol.FSInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	vol.fsinfo = fsinfo
+	util.Debugf("%s:%s fsinfo=%#v", addr, dirpath, fsinfo)
+
+	return vol, nil
+}
+
+// wraps the Call function to check status and decode errors
+func (v *Target) call(c interface{}) (io.ReadSeeker, error) {
+	res, err := v.Call(c)
+	if err != nil {
+		return nil, err
+	}
+
+	status, err := xdr.ReadUint32(res)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = NFS3Error(status); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (v *Target) FSInfo() (*FSInfo, error) {
+	type FSInfoArgs struct {
+		rpc.Header
+		FsRoot []byte
+	}
+
+	res, err := v.call(&FSInfoArgs{
+		Header: rpc.Header{
+			Rpcvers: 2,
+			Prog:    Nfs3Prog,
+			Vers:    Nfs3Vers,
+			Proc:    NFSProc3FSInfo,
+			Cred:    v.auth,
+			Verf:    rpc.AuthNull,
+		},
+		FsRoot: v.fh,
+	})
+
+	if err != nil {
+		util.Debugf("fsroot: %s", err.Error())
+		return nil, err
+	}
+
+	fsinfo := new(FSInfo)
+	if err = xdr.Read(res, fsinfo); err != nil {
+		return nil, err
+	}
+
+	return fsinfo, nil
+}
+
+// Lookup returns attributes and the file handle to a given dirent
+func (v *Target) Lookup(p string) (os.FileInfo, []byte, error) {
+	var (
+		err   error
+		fattr *Fattr
+		fh    = v.fh
+	)
+
+	// desecend down a path heirarchy to get the last elem's fh
+	dirents := strings.Split(path.Clean(p), "/")
+	for _, dirent := range dirents {
+		// we're assuming the root is always the root of the mount
+		if dirent == "." || dirent == "" {
+			util.Debugf("root -> 0x%x", fh)
+			continue
+		}
+
+		fattr, fh, err = v.lookup(fh, dirent)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		//util.Debugf("%s -> 0x%x", dirent, fh)
+	}
+
+	return fattr, fh, nil
+}
+
+// lookup returns the same as above, but by fh and name
+func (v *Target) lookup(fh []byte, name string) (*Fattr, []byte, error) {
+	type Lookup3Args struct {
+		rpc.Header
+		What Diropargs3
+	}
+
+	type LookupOk struct {
+		FH      []byte
+		Attr    PostOpAttr
+		DirAttr PostOpAttr
+	}
+
+	res, err := v.call(&Lookup3Args{
+		Header: rpc.Header{
+			Rpcvers: 2,
+			Prog:    Nfs3Prog,
+			Vers:    Nfs3Vers,
+			Proc:    NFSProc3Lookup,
+			Cred:    v.auth,
+			Verf:    rpc.AuthNull,
+		},
+		What: Diropargs3{
+			FH:       fh,
+			Filename: name,
+		},
+	})
+
+	if err != nil {
+		util.Debugf("lookup(%s): %s", name, err.Error())
+		return nil, nil, err
+	}
+
+	lookupres := new(LookupOk)
+	if err := xdr.Read(res, lookupres); err != nil {
+		util.Errorf("lookup(%s) failed to parse return: %s", name, err)
+		util.Debugf("lookup partial decode: %+v", *lookupres)
+		return nil, nil, err
+	}
+
+	util.Debugf("lookup(%s): FH 0x%x, attr: %+v", name, lookupres.FH, lookupres.Attr.Attr)
+	return &lookupres.Attr.Attr, lookupres.FH, nil
+}
+
+func (v *Target) ReadDirPlus(dir string) ([]*EntryPlus, error) {
+	_, fh, err := v.Lookup(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	return v.readDirPlus(fh)
+}
+
+func (v *Target) readDirPlus(fh []byte) ([]*EntryPlus, error) {
+	cookie := uint64(0)
+	cookieVerf := uint64(0)
+	eof := false
+
+	type ReadDirPlus3Args struct {
+		rpc.Header
+		FH         []byte
+		Cookie     uint64
+		CookieVerf uint64
+		DirCount   uint32
+		MaxCount   uint32
+	}
+
+	type DirListPlus3 struct {
+		IsSet bool      `xdr:"union"`
+		Entry EntryPlus `xdr:"unioncase=1"`
+	}
+
+	type DirListOK struct {
+		DirAttrs   PostOpAttr
+		CookieVerf uint64
+	}
+
+	var entries []*EntryPlus
+	for !eof {
+		res, err := v.call(&ReadDirPlus3Args{
+			Header: rpc.Header{
+				Rpcvers: 2,
+				Prog:    Nfs3Prog,
+				Vers:    Nfs3Vers,
+				Proc:    NFSProc3ReadDirPlus,
+				Cred:    v.auth,
+				Verf:    rpc.AuthNull,
+			},
+			FH:         fh,
+			Cookie:     cookie,
+			CookieVerf: cookieVerf,
+			DirCount:   512,
+			MaxCount:   4096,
+		})
+
+		if err != nil {
+			util.Debugf("readdir(%x): %s", fh, err.Error())
+			return nil, err
+		}
+
+		// The dir list entries are so-called "optional-data".  We need to check
+		// the Follows fields before continuing down the array.  Effectively, it's
+		// an encoding used to flatten a linked list into an array where the
+		// Follows field is set when the next idx has data. See
+		// https://tools.ietf.org/html/rfc4506.html#section-4.19 for details.
+		dirlistOK := new(DirListOK)
+		if err = xdr.Read(res, dirlistOK); err != nil {
+			util.Errorf("readdir failed to parse result (%x): %s", fh, err.Error())
+			util.Debugf("partial dirlist: %+v", dirlistOK)
+			return nil, err
+		}
+
+		for {
+			var item DirListPlus3
+			if err = xdr.Read(res, &item); err != nil {
+				util.Errorf("readdir failed to parse directory entry, aborting")
+				util.Debugf("partial dirent: %+v", item)
+				return nil, err
+			}
+
+			if !item.IsSet {
+				break
+			}
+
+			cookie = item.Entry.Cookie
+			entries = append(entries, &item.Entry)
+		}
+
+		if err = xdr.Read(res, &eof); err != nil {
+			util.Errorf("readdir failed to determine presence of more data to read, aborting")
+			return nil, err
+		}
+
+		util.Debugf("No EOF for dirents so calling back for more")
+		cookieVerf = dirlistOK.CookieVerf
+	}
+
+	return entries, nil
+}
+
+// Creates a directory of the given name and returns its handle
+func (v *Target) Mkdir(path string, perm os.FileMode) ([]byte, error) {
+	dir, newDir := filepath.Split(path)
+	_, fh, err := v.Lookup(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	type MkdirArgs struct {
+		rpc.Header
+		Where Diropargs3
+		Attrs Sattr3
+	}
+
+	type MkdirOk struct {
+		FH     PostOpFH3
+		Attr   PostOpAttr
+		DirWcc WccData
+	}
+
+	args := &MkdirArgs{
+		Header: rpc.Header{
+			Rpcvers: 2,
+			Prog:    Nfs3Prog,
+			Vers:    Nfs3Vers,
+			Proc:    NFSProc3Mkdir,
+			Cred:    v.auth,
+			Verf:    rpc.AuthNull,
+		},
+		Where: Diropargs3{
+			FH:       fh,
+			Filename: newDir,
+		},
+		Attrs: Sattr3{
+			Mode: SetMode{
+				SetIt: true,
+				Mode:  uint32(perm.Perm()),
+			},
+		},
+	}
+	res, err := v.call(args)
+
+	if err != nil {
+		util.Debugf("mkdir(%s): %s", path, err.Error())
+		util.Debugf("mkdir args (%+v)", args)
+		return nil, err
+	}
+
+	mkdirres := new(MkdirOk)
+	if err := xdr.Read(res, mkdirres); err != nil {
+		util.Errorf("mkdir(%s) failed to parse return: %s", path, err)
+		util.Debugf("mkdir(%s) partial response: %+v", mkdirres)
+		return nil, err
+	}
+
+	util.Debugf("mkdir(%s): created successfully (0x%x)", path, fh)
+	return mkdirres.FH.FH, nil
+}
+
+// Create a file with name the given mode
+func (v *Target) Create(path string, perm os.FileMode) ([]byte, error) {
+	dir, newFile := filepath.Split(path)
+	_, fh, err := v.Lookup(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	type How struct {
+		// 0 : UNCHECKED (default)
+		// 1 : GUARDED
+		// 2 : EXCLUSIVE
+		Mode uint32
+		Attr Sattr3
+	}
+	type Create3Args struct {
+		rpc.Header
+		Where Diropargs3
+		HW    How
+	}
+
+	type Create3Res struct {
+		FH     PostOpFH3
+		Attr   PostOpAttr
+		DirWcc WccData
+	}
+
+	res, err := v.call(&Create3Args{
+		Header: rpc.Header{
+			Rpcvers: 2,
+			Prog:    Nfs3Prog,
+			Vers:    Nfs3Vers,
+			Proc:    NFSProc3Create,
+			Cred:    v.auth,
+			Verf:    rpc.AuthNull,
+		},
+		Where: Diropargs3{
+			FH:       fh,
+			Filename: newFile,
+		},
+		HW: How{
+			Attr: Sattr3{
+				Mode: SetMode{
+					SetIt: true,
+					Mode:  uint32(perm.Perm()),
+				},
+			},
+		},
+	})
+
+	if err != nil {
+		util.Debugf("create(%s): %s", path, err.Error())
+		return nil, err
+	}
+
+	status := new(Create3Res)
+	if err = xdr.Read(res, status); err != nil {
+		return nil, err
+	}
+
+	util.Debugf("create(%s): created successfully", path)
+	return status.FH.FH, nil
+}
+
+// Remove a file
+func (v *Target) Remove(path string) error {
+	parentDir, deleteFile := filepath.Split(path)
+	_, fh, err := v.Lookup(parentDir)
+	if err != nil {
+		return err
+	}
+
+	return v.remove(fh, deleteFile)
+}
+
+// remove the named file from the parent (fh)
+func (v *Target) remove(fh []byte, deleteFile string) error {
+	type RemoveArgs struct {
+		rpc.Header
+		Object Diropargs3
+	}
+
+	_, err := v.call(&RemoveArgs{
+		Header: rpc.Header{
+			Rpcvers: 2,
+			Prog:    Nfs3Prog,
+			Vers:    Nfs3Vers,
+			Proc:    NFSProc3Remove,
+			Cred:    v.auth,
+			Verf:    rpc.AuthNull,
+		},
+		Object: Diropargs3{
+			FH:       fh,
+			Filename: deleteFile,
+		},
+	})
+
+	if err != nil {
+		util.Debugf("remove(%s): %s", deleteFile, err.Error())
+		return err
+	}
+
+	return nil
+}
+
+// RmDir removes a non-empty directory
+func (v *Target) RmDir(path string) error {
+	dir, deletedir := filepath.Split(path)
+	_, fh, err := v.Lookup(dir)
+	if err != nil {
+		return err
+	}
+
+	return v.rmDir(fh, deletedir)
+}
+
+// delete the named directory from the parent directory (fh)
+func (v *Target) rmDir(fh []byte, name string) error {
+	type RmDir3Args struct {
+		rpc.Header
+		Object Diropargs3
+	}
+
+	_, err := v.call(&RmDir3Args{
+		Header: rpc.Header{
+			Rpcvers: 2,
+			Prog:    Nfs3Prog,
+			Vers:    Nfs3Vers,
+			Proc:    NFSProc3RmDir,
+			Cred:    v.auth,
+			Verf:    rpc.AuthNull,
+		},
+		Object: Diropargs3{
+			FH:       fh,
+			Filename: name,
+		},
+	})
+
+	if err != nil {
+		util.Debugf("rmdir(%s): %s", name, err.Error())
+		return err
+	}
+
+	util.Debugf("rmdir(%s): deleted successfully", name)
+	return nil
+}
+
+func (v *Target) RemoveAll(path string) error {
+	parentDir, deleteDir := filepath.Split(path)
+	_, parentDirfh, err := v.Lookup(parentDir)
+	if err != nil {
+		return err
+	}
+
+	// Easy path.  This is a directory and it's empty.  If not a dir or not an
+	// empty dir, this will throw an error.
+	err = v.rmDir(parentDirfh, deleteDir)
+	if err == nil || os.IsNotExist(err) {
+		return nil
+	}
+
+	// Collect the not a dir error.
+	if IsNotDirError(err) {
+		return err
+	}
+
+	_, deleteDirfh, err := v.lookup(parentDirfh, deleteDir)
+	if err != nil {
+		return err
+	}
+
+	if err = v.removeAll(deleteDirfh); err != nil {
+		return err
+	}
+
+	// Delete the directory we started at.
+	if err = v.rmDir(parentDirfh, deleteDir); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// removeAll removes the deleteDir recursively
+func (v *Target) removeAll(deleteDirfh []byte) error {
+
+	// BFS the dir tree recursively.  If dir, recurse, then delete the dir and
+	// all files.
+
+	// This is a directory, get all of its Entries
+	entries, err := v.readDirPlus(deleteDirfh)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		// skip "." and ".."
+		if entry.FileName == "." || entry.FileName == ".." {
+			continue
+		}
+
+		// If directory, recurse, then nuke it.  It should be empty when we get
+		// back.
+		if entry.Attr.Attr.Type == NF3Dir {
+			if entry.Handle.IsSet {
+				if err = v.removeAll(entry.Handle.FH); err != nil {
+					return err
+				}
+			}
+
+			err = v.rmDir(deleteDirfh, entry.FileName)
+		} else {
+
+			// nuke all files
+			err = v.remove(deleteDirfh, entry.FileName)
+		}
+
+		if err != nil {
+			util.Errorf("error deleting %s: %s", entry.FileName, err.Error())
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/nfsclient/util/log.go
+++ b/pkg/nfsclient/util/log.go
@@ -1,0 +1,69 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import "log"
+
+var DefaultLogger Logger
+
+type Logger interface {
+	SetDebug(bool)
+	Errorf(format string, args ...interface{})
+	Debugf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+}
+
+func init() {
+	DefaultLogger = &logger{}
+}
+
+type logger struct {
+	DebugLevel bool
+}
+
+func (l *logger) SetDebug(enable bool) {
+	l.DebugLevel = enable
+}
+
+func (l *logger) Errorf(format string, args ...interface{}) {
+	log.Printf(format, args...)
+}
+
+func (l *logger) Debugf(format string, args ...interface{}) {
+	if !l.DebugLevel {
+		return
+	}
+
+	log.Printf(format, args...)
+}
+
+func (l *logger) Infof(format string, args ...interface{}) {
+	log.Printf(format, args...)
+}
+
+func Errorf(format string, args ...interface{}) {
+	DefaultLogger.Errorf(format, args...)
+}
+
+func Debugf(format string, args ...interface{}) {
+	DefaultLogger.Debugf(format, args...)
+}
+
+func Infof(format string, args ...interface{}) {
+	DefaultLogger.Infof(format, args...)
+}

--- a/pkg/nfsclient/xdr/decode.go
+++ b/pkg/nfsclient/xdr/decode.go
@@ -1,0 +1,55 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+package xdr
+
+import (
+	"io"
+
+	xdr "github.com/rasky/go-xdr/xdr2"
+)
+
+func Read(r io.Reader, val interface{}) error {
+	_, err := xdr.Unmarshal(r, val)
+	return err
+}
+
+func ReadUint32(r io.Reader) (uint32, error) {
+	var n uint32
+	if err := Read(r, &n); err != nil {
+		return n, err
+	}
+
+	return n, nil
+}
+
+func ReadOpaque(r io.Reader) ([]byte, error) {
+	length, err := ReadUint32(r)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, length)
+	if _, err = r.Read(buf); err != nil {
+		return nil, err
+	}
+
+	return buf, nil
+}
+
+func ReadUint32List(r io.Reader) ([]uint32, error) {
+	length, err := ReadUint32(r)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := make([]uint32, length)
+
+	for i := 0; i < int(length); i++ {
+		buf[i], err = ReadUint32(r)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return buf, nil
+}

--- a/pkg/nfsclient/xdr/encode.go
+++ b/pkg/nfsclient/xdr/encode.go
@@ -1,0 +1,14 @@
+// Copyright © 2017 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: BSD-2-Clause
+package xdr
+
+import (
+	"io"
+
+	xdr "github.com/rasky/go-xdr/xdr2"
+)
+
+func Write(w io.Writer, val interface{}) error {
+	_, err := xdr.Marshal(w, val)
+	return err
+}


### PR DESCRIPTION
Implementuje checker na existenci NFS exportu na serveru
Zapnuti checkeru je optional pomoci nastaveni os.ENV na hodnotu **true**.

Defaultni hodnota je **false**.

### NFS server neni dostupny sitove
Rekoncilace je ukoncena a do **status.phase** je propsan stav **Error**. Nevytvari se vazby PV a PVC. Oprava je mozna editaci objektu a tim vyvolani jeho nove rekoncilace.

### NFS server neposkytuje pozadovany export
Rekoncilace je pozastavena na 10 sekund a pote znovu provedena. Ve **status.phase** je propsan stav **Pending**. Vazby PV a PVC se provedou az v pripade, ze server vrati pri rekoncilaci pozadovany export.