### PR TITLE
feat: Pridani informace do status pro svazani s PVC

### DIFF
--- a/api/v1/nfs_types.go
+++ b/api/v1/nfs_types.go
@@ -45,12 +45,14 @@ type NfsStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 	Phase   string `json:"phase,omitempty"`
+	PVCName string `json:"pvcName,omitempty"`
 	Message string `json:"message,omitempty"`
 }
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="STATUS",type=string,JSONPath=`.status.phase`
+//+kubebuilder:printcolumn:name="CLAIM",type=string,JSONPath=`.status.pvcName`
 //+kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
 // Nfs is the Schema for the nfs API

--- a/config/crd/bases/storage.cfy.cz_nfs.yaml
+++ b/config/crd/bases/storage.cfy.cz_nfs.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .status.phase
       name: STATUS
       type: string
+    - jsonPath: .status.pvcName
+      name: CLAIM
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
@@ -65,6 +68,8 @@ spec:
                 description: |-
                   INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
                   Important: Run "make" to regenerate code after modifying this file
+                type: string
+              pvcName:
                 type: string
             type: object
         type: object

--- a/internal/controller/nfs_controller.go
+++ b/internal/controller/nfs_controller.go
@@ -203,10 +203,16 @@ func (r *NfsReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		if err != nil {
 			return ctrl.Result{Requeue: true}, nil
 		}
-		statusUpdate := storagev1.NfsStatus{Phase: string(foundPVC.Status.Phase)}
+		var pvcName = foundPVC.Name
+		var pvcPhase = foundPVC.Status.Phase
+		statusUpdate := storagev1.NfsStatus{
+			PVCName: string(pvcName),
+			Phase:   string(pvcPhase),
+		}
 		nfs.Status = statusUpdate
 		if err := r.Status().Update(ctx, nfs); err != nil {
 			log.Error(err, "Failed to update Nfs status")
+			return ctrl.Result{Requeue: true}, nil
 		}
 	}
 


### PR DESCRIPTION
Pokud operator vytvori PVC a na to navazane PV, je do status.claim propsano jmeno PVC, ktere bylo vytvoreno. CLAIM je zobrazen ve sloupci pri jednoduchem vylistovani vsech objektu Nfs.